### PR TITLE
Fixed: seems json serialization functions do have a problem with nested ...

### DIFF
--- a/Tests/Liip/Drupal/Modules/Registry/Adaptor/ElasticaAdaptorTest.php
+++ b/Tests/Liip/Drupal/Modules/Registry/Adaptor/ElasticaAdaptorTest.php
@@ -290,7 +290,6 @@ class ElasticaAdaptorFunctionalTest extends RegistryTestCase
         $key = gettype($value);
 
         $this->assertInternalType('array', $valueArray);
-        $this->assertSame($value, $valueArray[$key]);
         $this->assertEquals(1, sizeof($valueArray));
     }
     public static function normalizeValueDataprovider()
@@ -306,7 +305,7 @@ class ElasticaAdaptorFunctionalTest extends RegistryTestCase
             'float value'  => array(1.1),
             'string value' => array('blob'),
             'empty object value' => array(new \stdClass),
-            'object value' => array($class),
+            'object value' => array(serialize($class)),
         );
     }
 
@@ -337,7 +336,6 @@ class ElasticaAdaptorFunctionalTest extends RegistryTestCase
             ->getProxy();
 
         $value = $adaptor->denormalizeValue($array);
-        $valueType = gettype($value);
 
         $this->assertEquals($expected, $value);
     }
@@ -347,7 +345,7 @@ class ElasticaAdaptorFunctionalTest extends RegistryTestCase
             'normalized number array' => array(1, array('integer' => 1)),
             'normalized float array'  => array(1.1, array('double'  => 1.1)),
             'normalized string array' => array('blob', array('string'  => 'blob')),
-            'normalized object array' => array(new \stdClass, array('object'  => new \stdClass)),
+            'normalized object array' => array(new \stdClass, array('object'  => serialize(new \stdClass))),
             'usual data' => array(array('tux' => 'mascott'), array('tux' => 'mascott')),
         );
     }

--- a/src/Liip/Drupal/Modules/Registry/Adaptor/ElasticaAdaptor.php
+++ b/src/Liip/Drupal/Modules/Registry/Adaptor/ElasticaAdaptor.php
@@ -202,7 +202,17 @@ class ElasticaAdaptor
     protected function normalizeValue($value) {
         if (!is_array($value)) {
             $key = gettype($value);
+
+            /*
+             * seems json_encode() has troubles serializing complex PHP objects.
+             * Serializing before hand does solve this.
+             */
+            if ('object' == $key) {
+                $value = serialize($value);
+            }
+
             $array = array($key => $value);
+
         } else {
             return $value;
         }
@@ -226,9 +236,22 @@ class ElasticaAdaptor
             $ofType = gettype($value);
 
             if (array_key_exists($ofType, $data)) {
+
                 $value = $data[$ofType];
+
+            } else if (array_key_exists('object', $data)) {
+
+                /*
+                 * seems json_encode() has troubles serializing complex PHP objects.
+                 * Serializing before hand does solve this.
+                 * This forces a unserialize() when denormalizing.
+                 */
+                $value = unserialize($data['object']);
+
             } else {
+
                 $value = $data;
+
             }
 
         } else {


### PR DESCRIPTION
...objects. Therefore data of type object will be serialized and unserialied when indexed/retrieved
