### PR TITLE
Bug fix: init() does not act correct.

### DIFF
--- a/Tests/Liip/Drupal/Modules/Registry/Lucene/ElasticsearchTest.php
+++ b/Tests/Liip/Drupal/Modules/Registry/Lucene/ElasticsearchTest.php
@@ -68,24 +68,14 @@ class ElasticsearchTest extends RegistryTestCase
     public function testInit()
     {
         $registry = $this->getRegistryObject(self::$indexName);
+        $registry->destroy();
+        $registry->init();
 
         $this->assertAttributeEquals(self::$indexName, 'section', $registry);
         $this->assertInstanceOf(
             '\Liip\Drupal\Modules\Registry\Adaptor\ElasticaAdaptor',
             $this->readAttribute($registry, 'adaptor')
         );
-    }
-
-    /**
-     * @covers \Liip\Drupal\Modules\Registry\Lucene\Elasticsearch::init
-     */
-    public function testInitExpectingException()
-    {
-        $registry = $this->getRegistryObject(self::$indexName);
-
-        $this->setExpectedException('\\Liip\\Drupal\\Modules\\Registry\\RegistryException');
-
-        $registry->init();
     }
 
     /**

--- a/src/Liip/Drupal/Modules/Registry/Lucene/Elasticsearch.php
+++ b/src/Liip/Drupal/Modules/Registry/Lucene/Elasticsearch.php
@@ -37,10 +37,15 @@ class Elasticsearch extends Registry
     public function __construct($section, Common $dcc, Assertion $assertion)
     {
         $this->validateElasticaDependency();
+        $this->adaptor = new ElasticaAdaptor();
 
         parent::__construct($section, $dcc, $assertion);
 
-        $this->init();
+        // elastica will complain if the index name is not lowercase.
+        $this->section = strtolower($this->section);
+
+        $this->registry[$this->section] = $this->adaptor->getIndex($this->section);
+
     }
 
     /**
@@ -50,22 +55,10 @@ class Elasticsearch extends Registry
      */
     public function init()
     {
-        // elastica will complain if the index name is not lowercase.
-        $this->section = strtolower($this->section);
+        if (empty($this->registry[$this->section])) {
 
-        if(! empty($this->registry[$this->section])) {
-
-            throw new RegistryException(
-                $this->drupalCommonConnector->t(
-                    RegistryException::DUPLICATE_INITIATION_ATTEMPT_TEXT . '(@section)',
-                    array('@section' => $this->section)
-                ),
-                RegistryException::DUPLICATE_INITIATION_ATTEMPT_CODE
-            );
+            $this->registry[$this->section] = $this->adaptor->getIndex($this->section);
         }
-
-        $this->adaptor = new ElasticaAdaptor();
-        $this->registry[$this->section] = $this->adaptor->getIndex($this->section);
     }
 
     /**


### PR DESCRIPTION
Fixed: since the index is already created on object construction the init() method always caused an double initiation exception.
