### PR TITLE
Get all documents fix

### DIFF
--- a/Tests/Liip/Drupal/Modules/Registry/Lucene/ElasticsearchTest.php
+++ b/Tests/Liip/Drupal/Modules/Registry/Lucene/ElasticsearchTest.php
@@ -396,6 +396,24 @@ class ElasticsearchTest extends RegistryTestCase
 
     protected function setUp()
     {
+        // ElasticServer up?
+        $alive = @file_get_contents('http://localhost:9200');
+
+        if (is_bool($alive) && !$alive) {
+            $connectionRefused = true;
+        } else {
+
+            $response = json_decode($alive);
+            $connectionRefused = !(200 === $response->status);
+        }
+
+        if ($connectionRefused) {
+            $this->markTestSkipped(
+                'The ElasticSearch server is not responding. Please make sure to start the server before running the tests.'
+            );
+        }
+
+
         if (!class_exists('\Elastica\Index')) {
             $this->markTestSkipped(
                 'The elastica library is not available. Please make sure to install the elastica library as proposed by composer.'

--- a/Tests/Liip/Drupal/Modules/Registry/Lucene/ElasticsearchTest.php
+++ b/Tests/Liip/Drupal/Modules/Registry/Lucene/ElasticsearchTest.php
@@ -430,4 +430,50 @@ class ElasticsearchTest extends RegistryTestCase
             );
         }
     }
+
+    /**
+     * @dataProvider limitSettingsProvider
+     * @covers \Liip\Drupal\Modules\Registry\Lucene\Elasticsearch::getContent
+     */
+    public function testGetAmountOfDocuments($expected, $limit)
+    {
+        $values = array(
+            array('tux' => 'linus'),
+            array('tux1' => 'dolphin1'),
+            array('tux2' => 'linus1'),
+            array('tux3' => 'linus2'),
+            array('tux4' => 'dolphin2'),
+            array('tux5' => 'linus3'),
+            array('tux6' => 'dolphin3'),
+            array('Gnu' => 'dolphin'),
+            array('Gnu1' => 'dolphin5'),
+            array('Gnu2' => 'dolphin4'),
+            array('Gnu3' => 'dolphin6'),
+        );
+
+        $this->registerDocument(self::$indexName, 'toReadContentByIdFrom11', $values[0]);
+        $this->registerDocument(self::$indexName, 'toReadContentByIdFrom1', $values[1]);
+        $this->registerDocument(self::$indexName, 'toReadContentByIdFrom2', $values[2]);
+        $this->registerDocument(self::$indexName, 'toReadContentByIdFrom3', $values[3]);
+        $this->registerDocument(self::$indexName, 'toReadContentByIdFrom4', $values[4]);
+        $this->registerDocument(self::$indexName, 'toReadContentByIdFrom5', $values[5]);
+        $this->registerDocument(self::$indexName, 'toReadContentByIdFrom6', $values[5]);
+        $this->registerDocument(self::$indexName, 'toReadContentByIdFrom7', $values[6]);
+        $this->registerDocument(self::$indexName, 'toReadContentByIdFrom8', $values[7]);
+        $this->registerDocument(self::$indexName, 'toReadContentByIdFrom9', $values[8]);
+        $this->registerDocument(self::$indexName, 'toReadContentByIdFrom10', $values[9]);
+        $registry = $this->registerDocument(self::$indexName, 'toReadContentByIdFrom', $values[10]);
+
+        $this->assertCount($expected, $registry->getContent($limit));
+    }
+
+    public function limitSettingsProvider()
+    {
+        return array(
+            'just one document' => array(1, 1),
+            'all documents in index' => array(12, 0),
+            'default amount of documents' => array(10, 10),
+            'five documents' => array(5, 5),
+        );
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -7,16 +7,16 @@
     "packages": [
         {
             "name": "beberlei/assert",
-            "version": "v1.5",
+            "version": "v1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/beberlei/assert.git",
-                "reference": "b01a2868fcebcefc14ce3ae240d5b2fbba1d7126"
+                "reference": "97515db6b6c8fb254f5c3ce5730cdfa5a1e3fbf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/beberlei/assert/zipball/b01a2868fcebcefc14ce3ae240d5b2fbba1d7126",
-                "reference": "b01a2868fcebcefc14ce3ae240d5b2fbba1d7126",
+                "url": "https://api.github.com/repos/beberlei/assert/zipball/97515db6b6c8fb254f5c3ce5730cdfa5a1e3fbf4",
+                "reference": "97515db6b6c8fb254f5c3ce5730cdfa5a1e3fbf4",
                 "shasum": ""
             },
             "require": {
@@ -44,20 +44,20 @@
                 "assertion",
                 "validation"
             ],
-            "time": "2013-10-01 11:37:27"
+            "time": "2014-01-25 08:48:48"
         },
         {
             "name": "composer/installers",
             "version": "v1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/composer/installers",
-                "reference": "v1.0.0"
+                "url": "https://github.com/composer/installers.git",
+                "reference": "eae5f43226c8a3c7b98887c34287772cf227c275"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/composer/installers/archive/v1.0.0.zip",
-                "reference": "v1.0.0",
+                "url": "https://api.github.com/repos/composer/installers/zipball/eae5f43226c8a3c7b98887c34287772cf227c275",
+                "reference": "eae5f43226c8a3c7b98887c34287772cf227c275",
                 "shasum": ""
             },
             "replace": {
@@ -116,12 +116,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/liip/LiipDrupalConnectorModule.git",
-                "reference": "78233ec1ae4632df522a62875ef52f7419a4df00"
+                "reference": "93e338eeffa19074948534b51a9b4586010135a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liip/LiipDrupalConnectorModule/zipball/78233ec1ae4632df522a62875ef52f7419a4df00",
-                "reference": "78233ec1ae4632df522a62875ef52f7419a4df00",
+                "url": "https://api.github.com/repos/liip/LiipDrupalConnectorModule/zipball/93e338eeffa19074948534b51a9b4586010135a0",
+                "reference": "93e338eeffa19074948534b51a9b4586010135a0",
                 "shasum": ""
             },
             "require": {
@@ -169,7 +169,7 @@
                 "software quality",
                 "testing"
             ],
-            "time": "2013-10-23 10:01:02"
+            "time": "2014-01-28 10:36:44"
         },
         {
             "name": "liip/registryadaptor",
@@ -177,18 +177,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/liip/LiipRegistryAdaptor.git",
-                "reference": "526a675946ad0dbc2baa72bb6dc1ee38778af82f"
+                "reference": "0cb117200056e0f7bb1054932617af69b21780f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liip/LiipRegistryAdaptor/zipball/526a675946ad0dbc2baa72bb6dc1ee38778af82f",
-                "reference": "526a675946ad0dbc2baa72bb6dc1ee38778af82f",
+                "url": "https://api.github.com/repos/liip/LiipRegistryAdaptor/zipball/0cb117200056e0f7bb1054932617af69b21780f4",
+                "reference": "0cb117200056e0f7bb1054932617af69b21780f4",
                 "shasum": ""
             },
             "require": {
-                "beberlei/assert": "1.*",
+                "beberlei/assert": "~1.5",
                 "php": ">=5.3.8",
-                "ruflin/elastica": "v0.90.5.0"
+                "ruflin/elastica": "v0.90.7.0"
             },
             "require-dev": {
                 "lapistano/proxy-object": "dev-master"
@@ -223,20 +223,20 @@
                 "registry",
                 "software quality"
             ],
-            "time": "2013-11-04 22:16:34"
+            "time": "2014-01-16 09:18:28"
         },
         {
             "name": "ruflin/elastica",
-            "version": "v0.90.5.0",
+            "version": "v0.90.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ruflin/Elastica.git",
-                "reference": "8290c801df17df5ec3dff31f155867a30f793807"
+                "reference": "e36213362ef459f92e8b09167e537e9312f55ae3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ruflin/Elastica/zipball/8290c801df17df5ec3dff31f155867a30f793807",
-                "reference": "8290c801df17df5ec3dff31f155867a30f793807",
+                "url": "https://api.github.com/repos/ruflin/Elastica/zipball/e36213362ef459f92e8b09167e537e9312f55ae3",
+                "reference": "e36213362ef459f92e8b09167e537e9312f55ae3",
                 "shasum": ""
             },
             "require": {
@@ -252,11 +252,6 @@
                 "psr/log": "for logging"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.20.5.x-dev"
-                }
-            },
             "autoload": {
                 "psr-0": {
                     "Elastica": "lib/",
@@ -279,7 +274,7 @@
                 "client",
                 "search"
             ],
-            "time": "2013-10-27 12:53:43"
+            "time": "2013-11-23 21:35:18"
         }
     ],
     "packages-dev": [

--- a/src/Liip/Drupal/Modules/Registry/Database/MySql.php
+++ b/src/Liip/Drupal/Modules/Registry/Database/MySql.php
@@ -277,10 +277,19 @@ class MySql extends Registry
 
     /**
      * Provides the current content of the registry.
+     *
+     *
+     * NOTICE:
+     *  Setting $limit to anything else than 0 (zero) currently not have any affect on the amount of returned results.
+     *  This functionality is due to be implemented.
+     *
+     *
+     * @param integer $limit  Amount of documents to be returned in result set. If set to 0 (zero) all documents of the result set will be returned. Defaults to 0.
+     *
      * @throws \Liip\Drupal\Modules\Registry\RegistryException
      * @return array
      */
-    public function getContent()
+    public function getContent($limit = 0)
     {
         $this->registry[$this->section] = parent::getContent();
 

--- a/src/Liip/Drupal/Modules/Registry/Drupal/D7Config.php
+++ b/src/Liip/Drupal/Modules/Registry/Drupal/D7Config.php
@@ -144,9 +144,18 @@ class D7Config extends Registry
 
     /**
      * Provides the current set of registered items.
+     *
+     *
+     * NOTICE:
+     *  Setting $limit to anything else than 0 (zero) currently not have any affect on the amount of returned results.
+     *  This functionality is due to be implemented.
+     *
+     *
+     * @param integer $limit  Amount of documents to be returned in result set. If set to 0 (zero) all documents of the result set will be returned. Defaults to 0.
+     *
      * @return array
      */
-    public function getContent()
+    public function getContent($limit = 0)
     {
         $content = parent::getContent();
 

--- a/src/Liip/Drupal/Modules/Registry/Lucene/Elasticsearch.php
+++ b/src/Liip/Drupal/Modules/Registry/Lucene/Elasticsearch.php
@@ -192,11 +192,14 @@ class Elasticsearch extends Registry
 
     /**
      * Provides the current set of registered items.
+     *
+     * @param integer $limit  Amount of documents to be returned in result set. If set to 0 (zero) all documents of the result set will be returned. Defaults to 0.
+     *
      * @return array
      */
-    public function getContent()
+    public function getContent($limit = 0)
     {
-        return $this->getESAdaptor()->getDocuments($this->getRegistryIndex($this->section));
+        return $this->getESAdaptor()->getDocuments($this->getRegistryIndex($this->section), $limit);
     }
 
     /**

--- a/src/Liip/Drupal/Modules/Registry/Memory/Popo.php
+++ b/src/Liip/Drupal/Modules/Registry/Memory/Popo.php
@@ -47,9 +47,18 @@ class Popo extends Registry
     /**
      * Provides the current set of registered items.
      *
+     *
+     * NOTICE:
+     *  Setting $limit to anything else than 0 (zero) currently not have any affect on the amount of returned results.
+     *  This functionality is due to be implemented.
+     *
+     *
+     * @param integer $limit  Amount of documents to be returned in result set. If set to 0 (zero) all documents of the result set will be returned. Defaults to 0.
+     *
+     *
      * @return array
      */
-    public function getContent()
+    public function getContent($limit = 0)
     {
         return $this->registry[$this->section];
     }

--- a/src/Liip/Drupal/Modules/Registry/Registry.php
+++ b/src/Liip/Drupal/Modules/Registry/Registry.php
@@ -57,9 +57,18 @@ abstract class Registry implements RegistryInterface
 
     /**
      * Provides the current set of registered items.
+     *
+     *
+     * NOTICE:
+     *  Setting $limit to anything else than 0 (zero) currently not have any affect on the amount of returned results.
+     *  This functionality is due to be implemented.
+     *
+     *
+     * @param integer $limit  Amount of documents to be returned in result set. If set to 0 (zero) all documents of the result set will be returned. Defaults to 0.
+     *
      * @return array
      */
-    public function getContent()
+    public function getContent($limit = 0)
     {
         return $this->registry[$this->section];
     }
@@ -69,7 +78,7 @@ abstract class Registry implements RegistryInterface
      *
      * @param array $identifiers
      *
-     * @return array
+     * @return \Liip\Drupal\Modules\CrudAdmin\Entities\EntityInterface[]
      */
     public function getContentByIds(array $identifiers)
     {
@@ -89,7 +98,7 @@ abstract class Registry implements RegistryInterface
      * @param string $identifier
      * @param null $default
      *
-     * @return mixed
+     * @return \Liip\Drupal\Modules\CrudAdmin\Entities\EntityInterface
      */
     public function getContentById($identifier, $default = null)
     {

--- a/src/Liip/Drupal/Modules/Registry/RegistryInterface.php
+++ b/src/Liip/Drupal/Modules/Registry/RegistryInterface.php
@@ -40,9 +40,14 @@ interface RegistryInterface
 
     /**
      * Shall provide the current set of registered items.
+     *
+     * @param integer $limit  Amount of documents to be returned in result set. If set to 0 (zero) all documents of the result set shall be returned. Defaults to 10.
+     *
      * @return array
+     *
+     * @link http://stackoverflow.com/questions/8829468/elastic-search-query-to-return-all-records
      */
-    public function getContent();
+    public function getContent($limit = 10);
 
     /**
      * Shall find the registry item corresponding to the provided identifier.


### PR DESCRIPTION
It came to my attention that it is currently not possible to get all documents of a search result or an index returned by using getContents(). This is because of the fact that ElasticSearch it self limits the result set to 10 documents. 
This can only be increased by setting a new limt (»size« in ES language). Despite my thoughts setting it to 0 (zero) does not in creases the number of returned documents to all but actually make ES to return zero documents in the result set. Setting to to a big number instead, will bring the expected result.
Unfortunately the big number has to be higher than the amount of expected documents or ridiculously high to be sure to get all documents, but not too high to make ES crash with a memory limit exceeded exception ... tricky.

reference: http://stackoverflow.com/questions/8829468/elastic-search-query-to-return-all-records
